### PR TITLE
Corrected wrong tax calculation on shipping

### DIFF
--- a/Model/Method/Epay/Payment.php
+++ b/Model/Method/Epay/Payment.php
@@ -171,7 +171,7 @@ class Payment extends \Bambora\Online\Model\Method\AbstractPayment implements \B
                        "description" => isset($shippingDescription) ? $shippingDescription : $shippingText,
                        "quantity" => 1,
                        "price" =>$this->_bamboraHelper->convertPriceToMinorUnits(($order->getBaseShippingAmount() - $order->getBaseShippingDiscountAmount()), $minorUnits),
-                       "vat" =>$order->getBaseShippingTaxAmount() > 0 ? round(($order->getBaseShippingTaxAmount() / ($order->getBaseShippingInclTax() - $order->getBaseShippingDiscountAmount())) * 100) : 0
+                       "vat" =>$order->getBaseShippingTaxAmount() > 0 ? round(($order->getBaseShippingTaxAmount() / ($order->getBaseShippingAmount() - $order->getBaseShippingDiscountAmount())) * 100) : 0
                    );
 
             return json_encode($invoice, JSON_UNESCAPED_UNICODE);


### PR DESCRIPTION
The calculation of the tax percent was based on the total shipping amount (including the tax), but this should be based on what percentage it is of the shipping price excluding tax. Otherwise this will throw an error. In the epay window.

For example:

if the shipping price including tax is 100 DKK, and the tax is 25% that means the price excluding tax is 80 DKK.
So with previous calculation it would be 20/100*100 that would be 20%
With updated calculation it would be 20/80*100 which is 25% and the correct amount.