### PR TITLE
Added module requirements to composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+/composer.lock

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,18 @@
   ],
   "require": {
     "php": "~5.5.22|~5.6.0|7.0.2|7.0.4|~7.0.6|~7.1.0",
+    "magento/framework": "100.* | 101.*",
+    "magento/module-backend": "100.* | 101.* | 102.*",
+    "magento/module-catalog": "100.* | 101.* | 102.*",
+    "magento/module-checkout": "100.*",
+    "magento/module-config": "100.* | 101.*",
+    "magento/module-payment": "100.*",
+    "magento/module-paypal": "100.*",
+    "magento/module-quote": "100.* | 101.*",
+    "magento/module-sales": "100.* | 101.*",
+    "magento/module-store": "100.*",
+    "magento/module-tax": "100.*",
+    "magento/module-ui": "100.* | 101.*",
     "zendframework/zend-soap": ">=2.4.6"
   },
   "autoload": {
@@ -15,5 +27,11 @@
     "psr-4": {
       "Bambora\\Online\\": ""
     }
-  }
+  },
+  "repositories": [
+    {
+      "type": "composer",
+      "url": "https://repo.magento.com/"
+    }
+  ]
 }


### PR DESCRIPTION
The lack of requirements gives problems with shops where unnecessary Magento modules has been removed, this change solves this by making the module describe what Magento modules it requires to function

Requirements are tested for compatibility with Magento 2.0, 2.1 and 2.2