### PR TITLE
Enforce JSON response type for assets call

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/bambora-checkout-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/bambora-checkout-method.js
@@ -22,18 +22,7 @@ define(
                     template: 'Bambora_Online/payment/checkout-form',
                     paymentLogos: function () {
                         var result = ko.observable();
-                        var evaluator = function () {
-                            var response = $.get(window.checkoutConfig.payment.bambora_checkout.assetsUrl);
-                            if (!response) {
-                                response = new [];
-                            }
-                            return response;
-                        }
-                        ko.computed(
-                            function () {
-                                evaluator.call(this).done(result);
-                            }
-                        );
+                        $.get(window.checkoutConfig.payment.bambora_checkout.assetsUrl, null, result, 'json');
                         return result;
                     }()
                 },


### PR DESCRIPTION
Hi!

We sometimes have a situation when AJAX call to `bambora/checkout/assets` results in fatal error for whatever reason. HTTP response code is set like 500 or 503, and some text status is returned, e.g. "see exception logs ...".

https://prnt.sc/o3e38t

Current implementation does not check JSON format. Treats return string as success codes and iterates them, resulting in a lot of malformed images, one for each character in response.

https://prnt.sc/o3e3cl

Please review the change :)