### PR TITLE
Fix PHP 8.1 deprecation in Data helper

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -172,7 +172,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      */
     public function decryptData($data)
     {
-        return $this->_encryptor->decrypt(trim($data));
+        return $this->_encryptor->decrypt(trim((string) $data));
     }
 
     /**


### PR DESCRIPTION
**Error** 
When visiting the cart and checkout page:
`Exception #0 (Exception): Deprecated Functionality: trim(): Passing null to parameter #1 ($string) of type string is deprecated in /vendor/bambora/module-payment-magento2/Helper/Data.php on line 175`

**Solution**
Casting the variable to a string to fix the issue.
